### PR TITLE
Update PublishDir to include project name in output path

### DIFF
--- a/.github/workflows/release-pipline.yml
+++ b/.github/workflows/release-pipline.yml
@@ -101,7 +101,7 @@ jobs:
     # Step to publish the project
     - name: Publish
       shell: pwsh
-      run: msbuild ${{ env.uiaPeekProjectName }}/${{ env.uiaPeekProjectName }}.csproj /t:Publish /p:Configuration=Release /p:PublishDir=${{ env.binariesDirectory }}/publish/
+      run: msbuild ${{ env.uiaPeekProjectName }}/${{ env.uiaPeekProjectName }}.csproj /t:Publish /p:Configuration=Release /p:PublishDir=${{ env.binariesDirectory }}/${{ env.uiaPeekProjectName }}/publish/
 
     # Step to create a build artifact
     - name: Create Build Artifact


### PR DESCRIPTION
The msbuild publish step now outputs to a project-specific subdirectory within the binaries directory. This organizes published files by project name and avoids conflicts when publishing multiple projects.