### PR TITLE
Add -x64 suffix to artifact zip filename

### DIFF
--- a/.github/workflows/release-pipline.yml
+++ b/.github/workflows/release-pipline.yml
@@ -162,7 +162,7 @@ jobs:
         New-Item -Path "${{ env.artifactStagingDirectory }}" -ItemType Directory
         Compress-Archive `
             -Path ${{ env.binariesDirectory }}/${{ env.chromiumPeekProjectName }}/publish/* `
-            -DestinationPath ${{ env.artifactStagingDirectory }}/${{ env.chromiumPeekProjectName }}.${{ env.buildVersion }}.zip 
+            -DestinationPath ${{ env.artifactStagingDirectory }}/${{ env.chromiumPeekProjectName }}.${{ env.buildVersion }}-x64.zip 
 
     # Step to upload the build artifact
     - name: Upload a Build Artifact


### PR DESCRIPTION
The compressed archive's destination filename now includes the -x64 suffix to indicate the architecture, improving clarity for build artifacts.